### PR TITLE
Add less-than and greater-than operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,18 @@ let zeroFillRightShift = a >>> b
 let equality = a == b
 let referentialEquality = a === b
 
+let lessThan = a < b
+let lessThan2 = a < b < c # equivalent to `a < b && b < c`, except `b` is only evaluated once
+let lte = a <= b
+let lte2 = a <= b <= c
+let lessThan3 = a <= b < c
+
+let greaterThan = a > b
+let greaterThan2 = a > b > c
+let gte = a >= b
+let gte2 = a >= b >= c
+let greaterThan3 = a >= b > c
+
 # Logical
 let and = expr && expr
 let or = expr || expr


### PR DESCRIPTION
The operators can be chained like in Python, which is more intuitive than JS’s comparison of the truth value of one comparison to the other operand of the other comparison. I’m not entirely sure if `a < b > c` should be allowed, so I didn’t mention it.